### PR TITLE
Run some miri tests during CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,49 @@ jobs:
           toolchain: stable
           args: --release
 
+  miri-test:
+    runs-on: ${{ matrix.os }}
+    needs: rust-test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Get latest rust nightly version that has miri
+        id: versions
+        run: |
+          echo "::set-output name=rustc::nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)"
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            target
+            .cargo_home
+            .cargo
+          key: ${{ runner.os }}-no_pybindings-miri-${{ steps.versions.outputs.rustc }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-no_pybindings-miri-${{ steps.versions.outputs.rustc }}-
+
+      - name: Install rust ${{ steps.versions.outputs.rustc }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ steps.versions.outputs.rustc }}
+          profile: minimal
+          components: miri
+          override: true
+
+      - name: Run tests in miri
+        env:
+          RUSTFLAGS: "-Zrandomize-layout"
+          MIRIFLAGS: "-Zmiri-symbolic-alignment-check -Zmiri-check-number-validity -Zmiri-tag-raw-pointers -Zmiri-disable-isolation"
+        run: |
+          cargo miri test --no-fail-fast --all-targets
+
   python-test:
     runs-on: ${{ matrix.os }}
     needs: rust-test
@@ -93,8 +136,16 @@ jobs:
       - name: pytest
         run: poetry run pytest tests/python
 
+  testall:
+    runs-on: ubuntu-latest
+    name: Meta job for all tests
+    needs: [rust-test, miri-test, python-test]
+    steps:
+      - name: Done
+        run: echo "All tests successful."
+
   python-doc:
-    needs: python-test
+    needs: testall
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -142,7 +193,7 @@ jobs:
 
   rust-publish:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: python-test
+    needs: testall
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -158,7 +209,7 @@ jobs:
           cargo publish
 
   python-publish:
-    needs: python-test
+    needs: testall
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,6 +78,49 @@ jobs:
           toolchain: stable
           args: --release
 
+  miri-test:
+    runs-on: ${{ matrix.os }}
+    needs: rust-test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Get latest rust nightly version that has miri
+        id: versions
+        run: |
+          echo "::set-output name=rustc::nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)"
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            target
+            .cargo_home
+            .cargo
+          key: ${{ runner.os }}-no_pybindings-miri-${{ steps.versions.outputs.rustc }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-no_pybindings-miri-${{ steps.versions.outputs.rustc }}-
+
+      - name: Install rust ${{ steps.versions.outputs.rustc }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ steps.versions.outputs.rustc }}
+          profile: minimal
+          components: miri
+          override: true
+
+      - name: Run tests in miri
+        env:
+          RUSTFLAGS: "-Zrandomize-layout"
+          MIRIFLAGS: "-Zmiri-symbolic-alignment-check -Zmiri-check-number-validity -Zmiri-tag-raw-pointers -Zmiri-disable-isolation"
+        run: |
+          cargo miri test --no-fail-fast --all-targets
+
   python-test:
     runs-on: ${{ matrix.os }}
     needs: rust-test
@@ -133,7 +176,7 @@ jobs:
   testall:
     runs-on: ubuntu-latest
     name: Meta job for all tests
-    needs: [rust-test, python-test]
+    needs: [rust-test, miri-test, python-test]
     steps:
       - name: Done
         run: echo "All tests successful."

--- a/benches/lookup.rs
+++ b/benches/lookup.rs
@@ -9,7 +9,7 @@ use constriction::{
     },
     BitArray, Pos, Seek,
 };
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, Criterion};
 use num::cast::AsPrimitive;
 use rand::{RngCore, SeedableRng};
 use rand_xoshiro::Xoshiro256StarStar;
@@ -22,7 +22,11 @@ criterion_group!(
     round_trip_u16_u32_u16_8,
     round_trip_u16_u32_u16_12
 );
-criterion_main!(benches);
+
+#[cfg(not(miri))]
+criterion::criterion_main!(benches);
+#[cfg(miri)]
+fn main() {} // All benchmarks currently use FFI and therefore can't be tested in miri.
 
 fn round_trip_u32_u64_u16_12(c: &mut Criterion) {
     round_trip::<u32, u64, u16, 12>(c);

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -1830,6 +1830,7 @@ mod tests {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn decode_on_the_fly_stack() {
         fn encode_to_file(amt: u32) {
             let quantizer = DefaultLeakyQuantizer::new(-256..=255);

--- a/src/stream/chain.rs
+++ b/src/stream/chain.rs
@@ -1175,76 +1175,91 @@ mod tests {
     use alloc::vec;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_none() {
         generic_restore_many::<u32, u64, u32, 24>(4, 0);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_one() {
         generic_restore_many::<u32, u64, u32, 24>(5, 1);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_two() {
         generic_restore_many::<u32, u64, u32, 24>(5, 2);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_ten() {
         generic_restore_many::<u32, u64, u32, 24>(20, 10);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_twenty() {
         generic_restore_many::<u32, u64, u32, 24>(19, 20);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u32_u64_32() {
         generic_restore_many::<u32, u64, u32, 32>(1024, 1000);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u32_u64_24() {
         generic_restore_many::<u32, u64, u32, 24>(1024, 1000);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u32_u64_16() {
         generic_restore_many::<u32, u64, u16, 16>(1024, 1000);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u16_u64_16() {
         generic_restore_many::<u16, u64, u16, 16>(1024, 1000);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u32_u64_8() {
         generic_restore_many::<u32, u64, u8, 8>(1024, 1000);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u16_u64_8() {
         generic_restore_many::<u16, u64, u8, 8>(1024, 1000);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u8_u64_8() {
         generic_restore_many::<u8, u64, u8, 8>(1024, 1000);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u16_u32_16() {
         generic_restore_many::<u16, u32, u16, 16>(1024, 1000);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u16_u32_8() {
         generic_restore_many::<u16, u32, u8, 8>(1024, 1000);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn restore_many_u8_u32_8() {
         generic_restore_many::<u8, u32, u8, 8>(1024, 1000);
     }

--- a/src/stream/model.rs
+++ b/src/stream/model.rs
@@ -3697,6 +3697,7 @@ mod tests {
     use probability::distribution::{Binomial, Gaussian};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn leakily_quantized_normal() {
         let quantizer = LeakyQuantizer::<_, _, u32, 24>::new(-127..=127);
         for &std_dev in &[0.0001, 0.1, 3.5, 123.45, 1234.56] {
@@ -3708,6 +3709,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn leakily_quantized_binomial() {
         for &n in &[1, 2, 10, 100, 1000, 10_000] {
             for &p in &[1e-30, 1e-20, 1e-10, 0.1, 0.4, 0.9] {
@@ -3723,6 +3725,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn entropy() {
         let quantizer = LeakyQuantizer::<_, _, u32, 24>::new(-1000..=1000);
         for &std_dev in &[100., 200., 300.] {
@@ -3739,6 +3742,7 @@ mod tests {
     /// Test that `optimal_weights` reproduces the same distribution when fed with an
     /// already quantized model.
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn trivial_optimal_weights() {
         let hist = [
             56319u32, 134860032, 47755520, 60775168, 75699200, 92529920, 111023616, 130420736,
@@ -3764,6 +3768,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn nontrivial_optimal_weights() {
         let hist = [
             1u32, 186545, 237403, 295700, 361445, 433686, 509456, 586943, 663946, 737772, 1657269,
@@ -3808,6 +3813,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn contiguous_categorical() {
         let hist = [
             1u32, 186545, 237403, 295700, 361445, 433686, 509456, 586943, 663946, 737772, 1657269,
@@ -3825,6 +3831,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn non_contiguous_categorical() {
         let hist = [
             1u32, 186545, 237403, 295700, 361445, 433686, 509456, 586943, 663946, 737772, 1657269,

--- a/src/stream/queue.rs
+++ b/src/stream/queue.rs
@@ -1022,21 +1022,25 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_one() {
         generic_compress_few(core::iter::once(5), 1)
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_two() {
         generic_compress_few([2, 8].iter().cloned(), 1)
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_ten() {
         generic_compress_few(0..10, 2)
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_twenty() {
         generic_compress_few(-10..10, 4)
     }
@@ -1064,66 +1068,79 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u32_u64_32() {
         generic_compress_many::<u32, u64, u32, 32>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u32_u64_24() {
         generic_compress_many::<u32, u64, u32, 24>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u32_u64_16() {
         generic_compress_many::<u32, u64, u16, 16>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u32_u64_8() {
         generic_compress_many::<u32, u64, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u64_16() {
         generic_compress_many::<u16, u64, u16, 16>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u64_12() {
         generic_compress_many::<u16, u64, u16, 12>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u64_8() {
         generic_compress_many::<u16, u64, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u8_u64_8() {
         generic_compress_many::<u8, u64, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u32_16() {
         generic_compress_many::<u16, u32, u16, 16>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u32_12() {
         generic_compress_many::<u16, u32, u16, 12>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u32_8() {
         generic_compress_many::<u16, u32, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u8_u32_8() {
         generic_compress_many::<u8, u32, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u8_u16_8() {
         generic_compress_many::<u8, u16, u8, 8>();
     }
@@ -1219,6 +1236,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn seek() {
         const NUM_CHUNKS: usize = 100;
         const SYMBOLS_PER_CHUNK: usize = 100;

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -1169,21 +1169,25 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_one() {
         generic_compress_few(core::iter::once(5), 1)
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_two() {
         generic_compress_few([2, 8].iter().cloned(), 1)
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_ten() {
         generic_compress_few(0..10, 2)
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_twenty() {
         generic_compress_few(-10..10, 4)
     }
@@ -1213,66 +1217,79 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u32_u64_32() {
         generic_compress_many::<u32, u64, u32, 32>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u32_u64_24() {
         generic_compress_many::<u32, u64, u32, 24>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u32_u64_16() {
         generic_compress_many::<u32, u64, u16, 16>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u32_u64_8() {
         generic_compress_many::<u32, u64, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u64_16() {
         generic_compress_many::<u16, u64, u16, 16>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u64_12() {
         generic_compress_many::<u16, u64, u16, 12>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u64_8() {
         generic_compress_many::<u16, u64, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u8_u64_8() {
         generic_compress_many::<u8, u64, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u32_16() {
         generic_compress_many::<u16, u32, u16, 16>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u32_12() {
         generic_compress_many::<u16, u32, u16, 12>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u16_u32_8() {
         generic_compress_many::<u16, u32, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u8_u32_8() {
         generic_compress_many::<u8, u32, u8, 8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn compress_many_u8_u16_8() {
         generic_compress_many::<u8, u16, u8, 8>();
     }
@@ -1374,6 +1391,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn seek() {
         const NUM_CHUNKS: usize = 100;
         const SYMBOLS_PER_CHUNK: usize = 100;

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -929,7 +929,16 @@ mod tests {
             })
         }
 
-        let amt = 1000;
+        let amt;
+        #[cfg(not(miri))]
+        {
+            amt = 1000;
+        }
+        #[cfg(miri)]
+        {
+            amt = 100; // miri would take forever if we used `amt = 1000` here.
+        }
+
         let mut compressed = DefaultQueueEncoder::new();
 
         assert_eq!(compressed.len(), 0);

--- a/tests/random_data.rs
+++ b/tests/random_data.rs
@@ -130,6 +130,7 @@ fn compare(
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn grid() {
     let amts = [
         10,

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -1,6 +1,7 @@
 //! This is the example from `README.md`
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn example() {
     use constriction::stream::{model::DefaultLeakyQuantizer, stack::DefaultAnsCoder, Decode};
 


### PR DESCRIPTION
Unfortunately, most unit tests currently can't run in miri because they use foreign functions (e.g., the logarithm). But this at least runs some tests in miri, and it adds the machinery for running miri tests in CI, which will make it easier to add dedicated miri tests in the future.