### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,7 +128,35 @@ jobs:
         run: poetry run maturin develop --release --features pybindings
 
       - name: pytest
-        run: poetry run pytest tests/python
+        run: poetry run pytest tests/python | tee pytest.out
+
+      - name: Verify that pytest used correct python version (unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          USED_PYTHON_VERSION=$(grep -A1 -iE '^=+ test session starts =+$' pytest.out | perl -ne 'if ($_ =~ / -- Python (\d+\.\d+)\.\d+/i) { print "$1"; }')
+          echo "Expected python version: ${{ matrix.python-version }}"
+          echo "Found python version:    $USED_PYTHON_VERSION"
+          if [ "x${{ matrix.python-version }}y" == "x${USED_PYTHON_VERSION}y" ]; then
+            echo "Versions match."
+          else
+            echo "ERROR: versions don't match."
+            exit 1
+          fi
+
+      - name: Verify that pytest used correct python version (windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          $USED_PYTHON_VERSION = grep -A1 -iE '^=+ test session starts =+$' pytest.out | perl -ne 'if ($_ =~ / -- Python (\d+\.\d+)\.\d+/i) { print "$1"; }'
+          echo "Expected python version: ${{ matrix.python-version }}"
+          echo "Found python version:    $USED_PYTHON_VERSION"
+          if ( "x${{ matrix.python-version }}y" -eq "x${USED_PYTHON_VERSION}y" )
+          {
+            echo "Versions match."
+          }
+          else
+          {
+            throw "ERROR: versions don't match."
+          }
 
   testall:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,29 +99,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         uses: actions/checkout@v1
 
       - name: Set up Python ${{ matrix.python-version }}
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
           poetry install
 
       - name: Install latest stable Rust
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -129,11 +125,9 @@ jobs:
           override: true
 
       - name: Build Python package
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         run: poetry run maturin develop --release --features pybindings
 
       - name: pytest
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         run: poetry run pytest tests/python
 
   testall:
@@ -237,12 +231,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      - name: Set up Python 3.6
-        if: matrix.os != 'windows-latest'
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,42 +127,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         uses: actions/checkout@v1
 
       - name: Set up Python ${{ matrix.python-version }}
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
           poetry install
 
       - name: Install latest stable Rust
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
 
       - name: Get rust version
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         id: versions
         run: |
           echo "::set-output name=rustc::$(rustc --version | awk '{ print $2 }')"
 
       - name: Cache Rust dependencies
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         uses: actions/cache@v2
         with:
           path: |
@@ -174,11 +168,9 @@ jobs:
             ${{ runner.os }}-pybindings-rust-${{ steps.versions.outputs.rustc }}-
 
       - name: Build Python package
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         run: poetry run maturin develop --release --features pybindings
 
       - name: pytest
-        if: matrix.os != 'windows-latest' || matrix.python-version != '3.6'
         run: poetry run pytest tests/python
 
   testall:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -171,7 +171,35 @@ jobs:
         run: poetry run maturin develop --release --features pybindings
 
       - name: pytest
-        run: poetry run pytest tests/python
+        run: poetry run pytest tests/python | tee pytest.out
+
+      - name: Verify that pytest used correct python version (unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          USED_PYTHON_VERSION=$(grep -A1 -iE '^=+ test session starts =+$' pytest.out | perl -ne 'if ($_ =~ / -- Python (\d+\.\d+)\.\d+/i) { print "$1"; }')
+          echo "Expected python version: ${{ matrix.python-version }}"
+          echo "Found python version:    $USED_PYTHON_VERSION"
+          if [ "x${{ matrix.python-version }}y" == "x${USED_PYTHON_VERSION}y" ]; then
+            echo "Versions match."
+          else
+            echo "ERROR: versions don't match."
+            exit 1
+          fi
+
+      - name: Verify that pytest used correct python version (windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          $USED_PYTHON_VERSION = grep -A1 -iE '^=+ test session starts =+$' pytest.out | perl -ne 'if ($_ =~ / -- Python (\d+\.\d+)\.\d+/i) { print "$1"; }'
+          echo "Expected python version: ${{ matrix.python-version }}"
+          echo "Found python version:    $USED_PYTHON_VERSION"
+          if ( "x${{ matrix.python-version }}y" -eq "x${USED_PYTHON_VERSION}y" )
+          {
+            echo "Versions match."
+          }
+          else
+          {
+            throw "ERROR: versions don't match."
+          }
 
   testall:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 ]
 name = "constriction"
 readme = "README-python.md"
-requires-python = ">=3.6,<3.11"
+requires-python = ">=3.7,<3.11"
 
 [project.urls]
 changelog = "https://github.com/bamler-lab/constriction/releases"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,4 @@ wheel = "*"
 [build-system]
 authors = ["Robert Bamler <robert.bamler@uni-tuebingen.de>"]
 build-backend = "maturin"
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin>=0.13,<0.14"]


### PR DESCRIPTION
Maturin no longer supports compiling for python 3.6; python 3.6 has been out of extended support for almost a year, and Google Colab isn't using it any more either.