### PR TITLE
Fast categorical distribution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -717,7 +717,7 @@ unsafe_impl_bit_array!((u128, core::num::NonZeroU128),);
 /// initial zero chunks.
 fn bit_array_to_chunks_truncated<Data, Chunk>(
     data: Data,
-) -> impl Iterator<Item = Chunk> + ExactSizeIterator + DoubleEndedIterator
+) -> impl ExactSizeIterator<Item = Chunk> + DoubleEndedIterator
 where
     Data: BitArray + AsPrimitive<Chunk>,
     Chunk: BitArray,
@@ -767,7 +767,7 @@ impl<T> UnwrapInfallible<T> for Result<T, CoderError<Infallible, Infallible>> {
 /// despite using properties of generic parameters of an outer function.
 ///
 /// See discussion at <https://morestina.net/blog/1940>.
-macro_rules! generic_asserts {
+macro_rules! generic_static_asserts {
     (($($l:lifetime,)* $($($t:ident$(: $bound:path)?),+)? $(; $(const $c:ident:$ct:ty),+)?); $($label:ident: $test:expr);+$(;)?) => {
         #[allow(path_statements, clippy::no_effect)]
         {
@@ -777,7 +777,7 @@ macro_rules! generic_asserts {
                     const $label: () = assert!($test);
                 )+
             }
-            generic_asserts!{@nested Check::<$($l,)* $($($t,)+)? $($($c,)+)?>, $($label: $test;)+}
+            generic_static_asserts!{@nested Check::<$($l,)* $($($t,)+)? $($($c,)+)?>, $($label: $test;)+}
         }
     };
     (@nested $t:ty, $($label:ident: $test:expr;)+) => {
@@ -787,4 +787,4 @@ macro_rules! generic_asserts {
     }
 }
 
-pub(crate) use generic_asserts;
+pub(crate) use generic_static_asserts;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,7 +459,7 @@ pub trait Pos: PosSeek {
 /// let mut ans = DefaultAnsCoder::new();
 /// let probabilities = vec![0.03, 0.07, 0.1, 0.1, 0.2, 0.2, 0.1, 0.15, 0.05];
 /// let entropy_model = DefaultContiguousCategoricalEntropyModel
-///     ::from_floating_point_probabilities(&probabilities).unwrap();
+///     ::from_floating_point_probabilities_fast(&probabilities, None).unwrap();
 ///
 /// // Encode some symbols in two chunks and take a snapshot after each chunk.
 /// let symbols1 = vec![8, 2, 0, 7];

--- a/src/pybindings/mod.rs
+++ b/src/pybindings/mod.rs
@@ -346,6 +346,13 @@ impl<'py, D: ndarray::Dimension> PyReadonlyFloatArray<'py, D> {
         }
     }
 
+    fn cast_f32(&'py self) -> PyResult<Cow<'py, PyReadonlyArray<'py, f32, D>>> {
+        match self {
+            PyReadonlyFloatArray::F32(x) => Ok(Cow::Borrowed(x)),
+            PyReadonlyFloatArray::F64(x) => Ok(Cow::Owned(x.cast::<f32>(false)?.readonly())),
+        }
+    }
+
     fn len(&self) -> usize {
         match self {
             PyReadonlyFloatArray::F32(x) => x.len(),

--- a/src/stream/chain.rs
+++ b/src/stream/chain.rs
@@ -40,13 +40,13 @@
 //!         .iter()
 //!         .map(
 //!             |probs| DefaultContiguousCategoricalEntropyModel
-//!                 ::from_floating_point_probabilities(probs).unwrap()
+//!                 ::from_floating_point_probabilities_fast(probs, None).unwrap()
 //!         );
 //!     decoder.decode_symbols(entropy_models).collect::<Result<Vec<_>, _>>().unwrap()
 //! }
 //!
 //! // Let's define some sample binary data and some probabilities for our entropy models
-//! let data = vec![0x80d1_4131, 0xdda9_7c6c, 0x5017_a640, 0x0117_0a3d];
+//! let data = vec![0x80d1_4131, 0xdda9_7c6c, 0x5017_a640, 0x0117_0a3e];
 //! let mut probabilities = [
 //!     [0.1, 0.7, 0.1, 0.1], // Probabilities for the entropy model of the first decoded symbol.
 //!     [0.2, 0.2, 0.1, 0.5], // Probabilities for the entropy model of the second decoded symbol.
@@ -56,13 +56,13 @@
 //! // Decoding the binary data with an `AnsCoder` results in the symbols `[0, 0, 1]`.
 //! let mut ans_coder = DefaultAnsCoder::from_binary(data.clone()).unwrap();
 //! let symbols = decode_categoricals(&mut ans_coder, &probabilities);
-//! assert_eq!(symbols, [0, 0, 1]);
+//! assert_eq!(symbols, [0, 0, 2]);
 //!
 //! // Even if we change only the first entropy model (slightly), *all* decoded symbols can change:
 //! probabilities[0] = [0.09, 0.71, 0.1, 0.1]; // was: `[0.1, 0.7, 0.1, 0.1]`
 //! let mut ans_coder = DefaultAnsCoder::from_binary(data.clone()).unwrap();
 //! let symbols = decode_categoricals(&mut ans_coder, &probabilities);
-//! assert_eq!(symbols, [1, 0, 3]); // (instead of `[0, 0, 1]` from above)
+//! assert_eq!(symbols, [1, 0, 0]); // (instead of `[0, 0, 2]` from above)
 //! // It's no surprise that the first symbol changed since we changed its entropy model. But
 //! // note that the third symbol changed too even though we hadn't changed its entropy model.
 //! // --> Changes to entropy models (and also to compressed bits) have a *global* effect.

--- a/src/stream/chain.rs
+++ b/src/stream/chain.rs
@@ -101,8 +101,8 @@ use super::{
 };
 use crate::{
     backends::{ReadWords, WriteWords},
-    generic_asserts, BitArray, CoderError, DefaultEncoderFrontendError, NonZeroBitArray, Pos,
-    PosSeek, Seek, Stack,
+    generic_static_asserts, BitArray, CoderError, DefaultEncoderFrontendError, NonZeroBitArray,
+    Pos, PosSeek, Seek, Stack,
 };
 
 /// Experimental entropy coder for advanced variants of bitsback coding.
@@ -274,7 +274,7 @@ impl<Word: BitArray, State: BitArray, const PRECISION: usize>
     where
         Word: Into<State>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (State: BitArray, Word: BitArray; const PRECISION: usize);
             PROBABILITY_SUPPORTS_PRECISION: State::BITS >= Word::BITS + PRECISION;
             NON_ZERO_PRECISION: PRECISION > 0;
@@ -608,7 +608,7 @@ where
     where
         RemaindersBackend: WriteWords<Word>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (State: BitArray, Word: BitArray; const PRECISION: usize, const NEW_PRECISION: usize);
             PRECISION_MUST_NOT_DECREASE: NEW_PRECISION >= PRECISION;
             WORD_MUST_SUPPORT_NEW_PRECISION: NEW_PRECISION <= Word::BITS;
@@ -659,7 +659,7 @@ where
     where
         RemaindersBackend: ReadWords<Word, Stack>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (State: BitArray, Word: BitArray; const PRECISION: usize, const NEW_PRECISION: usize);
             PRECISION_MUST_NOT_INCREASE: NEW_PRECISION <= PRECISION;
             NEW_PRECISION_MUST_BE_NONZERO: NEW_PRECISION > 0;
@@ -757,7 +757,7 @@ where
     where
         RemaindersBackend: WriteWords<Word> + ReadWords<Word, Stack>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (State: BitArray, Word: BitArray; const PRECISION: usize, const NEW_PRECISION: usize);
             NEW_PRECISION_MUST_BE_NONZERO: NEW_PRECISION > 0;
             WORD_MUST_SUPPORT_NEW_PRECISION: NEW_PRECISION <= Word::BITS;
@@ -1050,7 +1050,7 @@ where
         M::Probability: Into<Self::Word>,
         Self::Word: AsPrimitive<M::Probability>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (State: BitArray, Word: BitArray; const PRECISION: usize);
             WORD_MUST_SUPPORT_PRECISION: PRECISION <= Word::BITS;
             PRECISION_MUST_BE_NONZERO: PRECISION > 0;
@@ -1147,7 +1147,7 @@ where
         M::Probability: Into<Self::Word>,
         Self::Word: AsPrimitive<M::Probability>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (State: BitArray, Word: BitArray; const PRECISION: usize);
             WORD_MUST_SUPPORT_PRECISION: PRECISION <= Word::BITS;
             PRECISION_MUST_BE_NONZERO: PRECISION > 0;

--- a/src/stream/model.rs
+++ b/src/stream/model.rs
@@ -3344,7 +3344,7 @@ pub struct LazyContiguousCategoricalEntropyModel<Probability, F, Table, const PR
 /// See:
 /// - [`LazyContiguousCategoricalEntropyModel`]
 /// - [discussion of presets](super#presets)
-pub type DefaultLazyContiguousCategoricalEntropyModel<F = f32, Table = Vec<u32>> =
+pub type DefaultLazyContiguousCategoricalEntropyModel<F = f32, Table = Vec<f32>> =
     LazyContiguousCategoricalEntropyModel<u32, F, Table, 24>;
 
 /// Type alias for a [`LazyContiguousCategoricalEntropyModel`] optimized for compatibility with

--- a/src/stream/model.rs
+++ b/src/stream/model.rs
@@ -3510,7 +3510,8 @@ where
             .wrapping_sub(&left_cumulative)
             .into_nonzero()
             .expect("leakiness should guarantee nonzero probabilities.");
-        return (next_symbol.wrapping_sub(1), left_cumulative, probability);
+
+        (next_symbol.wrapping_sub(1), left_cumulative, probability)
     }
 }
 
@@ -4413,6 +4414,7 @@ mod tests {
 
     #[test]
     fn lazy_contiguous_categorical() {
+        #[allow(clippy::excessive_precision)]
         let unnormalized_probs: [f32; 30] = [
             4.22713972, 1e-20, 0.22221771, 0.00927659, 1.58383270, 0.95804675, 0.78104103,
             0.81518454, 0.75206966, 0.58559047, 0.00024284, 1.81382388, 3.22535052, 0.77940434,
@@ -4420,7 +4422,7 @@ mod tests {
             0.00778274, 0.18957551, 10.2402638, 3.36959484, 0.02624742, 1.85103708, 0.25614601,
             0.09754817, 0.27998250,
         ];
-        let normalization = 33.53830221;
+        let normalization = 33.538302;
 
         const PRECISION: usize = 32;
         let model =

--- a/src/stream/model.rs
+++ b/src/stream/model.rs
@@ -166,7 +166,7 @@ pub use probability::distribution::Distribution;
 /// [`probability`]: https://docs.rs/probability/latest/probability/
 pub use probability::distribution::Inverse;
 
-use crate::{generic_asserts, wrapping_pow2, BitArray, NonZeroBitArray};
+use crate::{generic_static_asserts, wrapping_pow2, BitArray, NonZeroBitArray};
 
 /// Base trait for probabilistic models of a data source.
 ///
@@ -1208,7 +1208,7 @@ where
     ///
     /// [`quantize`]: #method.quantize
     pub fn new(support: RangeInclusive<Symbol>) -> Self {
-        generic_asserts!(
+        generic_static_asserts!(
             (Probability: BitArray; const PRECISION: usize);
             PROBABILITY_MUST_SUPPORT_PRECISION: PRECISION <= Probability::BITS;
             PRECISION_MUST_BE_NONZERO: PRECISION > 0;
@@ -1806,7 +1806,7 @@ pub trait SymbolTable<Symbol, Probability: BitArray> {
         &self,
         quantile: Probability,
     ) -> (Symbol, Probability, Probability::NonZero) {
-        generic_asserts!(
+        generic_static_asserts!(
             (Probability: BitArray; const PRECISION: usize);
             PROBABILITY_MUST_SUPPORT_PRECISION: PRECISION <= Probability::BITS;
             PRECISION_MUST_BE_NONZERO: PRECISION > 0;
@@ -3171,7 +3171,7 @@ where
     P::Item: Borrow<Probability>,
     Op: FnMut(Symbol, Probability, Probability) -> Result<(), ()>,
 {
-    generic_asserts!(
+    generic_static_asserts!(
         (Probability: BitArray; const PRECISION: usize);
         PROBABILITY_MUST_SUPPORT_PRECISION: PRECISION <= Probability::BITS;
         PRECISION_MUST_BE_NONZERO: PRECISION > 0;
@@ -3215,7 +3215,7 @@ where
     f64: AsPrimitive<Probability>,
     usize: AsPrimitive<Probability>,
 {
-    generic_asserts!(
+    generic_static_asserts!(
         (Probability: BitArray; const PRECISION: usize);
         PROBABILITY_MUST_SUPPORT_PRECISION: PRECISION <= Probability::BITS;
         PRECISION_MUST_BE_NONZERO: PRECISION > 0;
@@ -3485,7 +3485,7 @@ where
         P: IntoIterator,
         P::Item: Borrow<Probability>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Probability: BitArray; const PRECISION: usize);
             PROBABILITY_MUST_SUPPORT_PRECISION: PRECISION <= Probability::BITS;
             PRECISION_MUST_BE_NONZERO: PRECISION > 0;
@@ -3526,7 +3526,7 @@ where
     where
         M: IterableEntropyModel<'m, PRECISION, Symbol = Symbol, Probability = Probability> + ?Sized,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Probability: BitArray; const PRECISION: usize);
             PROBABILITY_MUST_SUPPORT_PRECISION: PRECISION <= Probability::BITS;
             PRECISION_MUST_BE_NONZERO: PRECISION > 0;
@@ -3597,7 +3597,7 @@ where
         I: IntoIterator,
         I::Item: Borrow<Probability>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Probability: BitArray; const PRECISION: usize);
             PROBABILITY_MUST_SUPPORT_PRECISION: PRECISION <= Probability::BITS;
             PRECISION_MUST_BE_NONZERO: PRECISION > 0;
@@ -3749,7 +3749,7 @@ where
         &self,
         quantile: Probability,
     ) -> (Symbol, Probability, Probability::NonZero) {
-        generic_asserts!(
+        generic_static_asserts!(
             (Probability: BitArray; const PRECISION: usize);
             PROBABILITY_MUST_SUPPORT_PRECISION: PRECISION <= Probability::BITS;
             PRECISION_MUST_BE_NONZERO: PRECISION > 0;

--- a/src/stream/queue.rs
+++ b/src/stream/queue.rs
@@ -1229,8 +1229,8 @@ mod tests {
         ];
         let categorical_probabilities = hist.iter().map(|&x| x as f64).collect::<Vec<_>>();
         let categorical =
-            ContiguousCategoricalEntropyModel::<Probability, _, PRECISION>::from_floating_point_probabilities(
-                &categorical_probabilities,
+            ContiguousCategoricalEntropyModel::<Probability, _, PRECISION>::from_floating_point_probabilities_fast::<f64>(
+                &categorical_probabilities,None
             )
             .unwrap();
         let mut symbols_categorical = Vec::with_capacity(AMT);

--- a/src/stream/queue.rs
+++ b/src/stream/queue.rs
@@ -48,7 +48,7 @@ use super::{
 };
 use crate::{
     backends::{AsReadWords, BoundedReadWords, Cursor, IntoReadWords, ReadWords, WriteWords},
-    generic_asserts, BitArray, CoderError, DefaultEncoderError, DefaultEncoderFrontendError,
+    generic_static_asserts, BitArray, CoderError, DefaultEncoderError, DefaultEncoderFrontendError,
     NonZeroBitArray, Pos, PosSeek, Queue, Seek, UnwrapInfallible,
 };
 
@@ -219,7 +219,7 @@ where
 {
     /// Creates an empty encoder for range coding.
     pub fn new() -> Self {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray);
             STATE_SUPPORTS_AT_LEAST_TWO_WORDS: State::BITS >= 2 * Word::BITS;
             STATE_SIZE_IS_MULTIPLE_OF_WORD_SIZE: State::BITS % Word::BITS == 0;
@@ -266,7 +266,7 @@ where
     ///
     /// [`AnsCoder`]: super::stack::AnsCoder
     pub fn with_backend(backend: Backend) -> Self {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray);
             STATE_SUPPORTS_AT_LEAST_TWO_WORDS: State::BITS >= 2 * Word::BITS;
             STATE_SIZE_IS_MULTIPLE_OF_WORD_SIZE: State::BITS % Word::BITS == 0;
@@ -434,7 +434,7 @@ where
         state: RangeCoderState<Word, State>,
         situation: EncoderSituation<Word>,
     ) -> Self {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray);
             STATE_SUPPORTS_AT_LEAST_TWO_WORDS: State::BITS >= 2 * Word::BITS;
             STATE_SIZE_IS_MULTIPLE_OF_WORD_SIZE: State::BITS % Word::BITS == 0;
@@ -551,7 +551,7 @@ where
         D::Probability: Into<Self::Word>,
         Self::Word: AsPrimitive<D::Probability>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray; const PRECISION: usize);
             PROBABILITY_SUPPORTS_PRECISION: State::BITS >= Word::BITS + PRECISION;
             NON_ZERO_PRECISION: PRECISION > 0;
@@ -688,7 +688,7 @@ where
     where
         Buf: IntoReadWords<Word, Queue, IntoReadWords = Backend>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray);
             STATE_SUPPORTS_AT_LEAST_TWO_WORDS: State::BITS >= 2 * Word::BITS;
             STATE_SIZE_IS_MULTIPLE_OF_WORD_SIZE: State::BITS % Word::BITS == 0;
@@ -705,7 +705,7 @@ where
     }
 
     pub fn with_backend(backend: Backend) -> Result<Self, Backend::ReadError> {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray);
             STATE_SUPPORTS_AT_LEAST_TWO_WORDS: State::BITS >= 2 * Word::BITS;
             STATE_SIZE_IS_MULTIPLE_OF_WORD_SIZE: State::BITS % Word::BITS == 0;
@@ -725,7 +725,7 @@ where
     where
         Buf: AsReadWords<'a, Word, Queue, AsReadWords = Backend>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray);
             STATE_SUPPORTS_AT_LEAST_TWO_WORDS: State::BITS >= 2 * Word::BITS;
             STATE_SIZE_IS_MULTIPLE_OF_WORD_SIZE: State::BITS % Word::BITS == 0;
@@ -754,7 +754,7 @@ where
         state: RangeCoderState<Word, State>,
         point: State,
     ) -> Result<Self, Backend> {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray);
             STATE_SUPPORTS_AT_LEAST_TWO_WORDS: State::BITS >= 2 * Word::BITS;
             STATE_SIZE_IS_MULTIPLE_OF_WORD_SIZE: State::BITS % Word::BITS == 0;
@@ -922,7 +922,7 @@ where
         D::Probability: Into<Self::Word>,
         Self::Word: AsPrimitive<D::Probability>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray; const PRECISION: usize);
             PROBABILITY_SUPPORTS_PRECISION: State::BITS >= Word::BITS + PRECISION;
             NON_ZERO_PRECISION: PRECISION > 0;

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -448,7 +448,7 @@ where
     /// let symbols = vec![8, 2, 0, 7];
     /// let probabilities = vec![0.03, 0.07, 0.1, 0.1, 0.2, 0.2, 0.1, 0.15, 0.05];
     /// let model = DefaultContiguousCategoricalEntropyModel
-    ///     ::from_floating_point_probabilities(&probabilities).unwrap();
+    ///     ::from_floating_point_probabilities_fast(&probabilities, None).unwrap();
     /// ans.encode_iid_symbols_reverse(&symbols, &model).unwrap();
     ///
     /// // Inspect the compressed data.
@@ -773,7 +773,7 @@ where
     /// let symbols = vec![8, 2, 0, 7];
     /// let probabilities = vec![0.03, 0.07, 0.1, 0.1, 0.2, 0.2, 0.1, 0.15, 0.05];
     /// let model = DefaultContiguousCategoricalEntropyModel
-    ///     ::from_floating_point_probabilities(&probabilities).unwrap();
+    ///     ::from_floating_point_probabilities_fast(&probabilities, None).unwrap();
     /// ans.encode_iid_symbols_reverse(&symbols, &model).unwrap();
     ///
     /// // Get the compressed data, consuming the ANS coder:
@@ -1341,8 +1341,8 @@ mod tests {
         ];
         let categorical_probabilities = hist.iter().map(|&x| x as f64).collect::<Vec<_>>();
         let categorical =
-            ContiguousCategoricalEntropyModel::<Probability, _, PRECISION>::from_floating_point_probabilities(
-                &categorical_probabilities,
+            ContiguousCategoricalEntropyModel::<Probability, _, PRECISION>::from_floating_point_probabilities_fast::<f64>(
+                &categorical_probabilities,None
             )
             .unwrap();
         let mut symbols_categorical = Vec::with_capacity(AMT);

--- a/src/stream/stack.rs
+++ b/src/stream/stack.rs
@@ -38,8 +38,9 @@ use crate::{
         self, AsReadWords, AsSeekReadWords, BoundedReadWords, Cursor, FallibleIteratorReadWords,
         IntoReadWords, IntoSeekReadWords, ReadWords, Reverse, WriteWords,
     },
-    bit_array_to_chunks_truncated, generic_asserts, BitArray, CoderError, DefaultEncoderError,
-    DefaultEncoderFrontendError, NonZeroBitArray, Pos, PosSeek, Seek, Stack, UnwrapInfallible,
+    bit_array_to_chunks_truncated, generic_static_asserts, BitArray, CoderError,
+    DefaultEncoderError, DefaultEncoderFrontendError, NonZeroBitArray, Pos, PosSeek, Seek, Stack,
+    UnwrapInfallible,
 };
 
 /// Entropy coder for both encoding and decoding on a stack.
@@ -256,7 +257,7 @@ where
     Backend: Default,
 {
     fn default() -> Self {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray);
             STATE_SUPPORTS_AT_LEAST_TWO_WORDS: State::BITS >= 2 * Word::BITS;
         );
@@ -310,7 +311,7 @@ where
     where
         Backend: ReadWords<Word, Stack>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray);
             STATE_SUPPORTS_AT_LEAST_TWO_WORDS: State::BITS >= 2 * Word::BITS;
         );
@@ -943,7 +944,7 @@ where
         M::Probability: Into<Self::Word>,
         Self::Word: AsPrimitive<M::Probability>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray; const PRECISION: usize);
             PROBABILITY_SUPPORTS_PRECISION: State::BITS >= Word::BITS + PRECISION;
             NON_ZERO_PRECISION: PRECISION > 0;
@@ -1012,7 +1013,7 @@ where
         M::Probability: Into<Self::Word>,
         Self::Word: AsPrimitive<M::Probability>,
     {
-        generic_asserts!(
+        generic_static_asserts!(
             (Word: BitArray, State:BitArray; const PRECISION: usize);
             PROBABILITY_SUPPORTS_PRECISION: State::BITS >= Word::BITS + PRECISION;
             NON_ZERO_PRECISION: PRECISION > 0;

--- a/src/symbol/huffman.rs
+++ b/src/symbol/huffman.rs
@@ -28,8 +28,9 @@ pub struct EncoderHuffmanTree {
     /// - root node if `x == 0`;
     /// - otherwise, the lowest significant bit distinguishes left vs right children,
     ///   and the parent node is at index `x >> 1`.
-    /// (This works the node with index 0, if it exists, is always a leaf node, i.e., it
-    /// cannot be any other node's parent node.)
+    ///
+    /// (This means that the node with index 0, if it exists, is always a leaf node,
+    /// i.e., it cannot be any other node's parent node.)
     ///
     /// It is guaranteed that `num_symbols != 0` i.e., `nodes` is not empty.
     nodes: Vec<usize>,

--- a/src/symbol/mod.rs
+++ b/src/symbol/mod.rs
@@ -167,7 +167,7 @@ pub struct SymbolCoder<Word: BitArray, S: Semantics, B = Vec<Word>> {
     ///   the backend (in case of a write backend) and/or if reading the next bit would
     ///   require obtaining a new word from the backend (in case of a read backend); This
     ///   includes the case of an empty `QueueEncoder`. In all of these cases, `current_word`
-    ///  as to be zero.
+    ///   as to be zero.
     /// - otherwise, `mask_last_written` has a single set bit which marks the position in
     ///   `current_word` where the next bit should be written if any.
     mask_last_written: Word,

--- a/tests/issue52.rs
+++ b/tests/issue52.rs
@@ -90,9 +90,10 @@ fn round_trip() {
         'H', 'e', 'l', 'o', ',', ' ', 'W', 'r', 'd', '!', 'G', 'b', 'y', '.',
     ];
     let counts = [1., 2., 3., 4., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 2.]; // The last entry is for the EOF token.
-    let probs =
-        DefaultContiguousCategoricalEntropyModel::from_floating_point_probabilities(&counts)
-            .unwrap();
+    let probs = DefaultContiguousCategoricalEntropyModel::from_floating_point_probabilities_fast(
+        &counts, None,
+    )
+    .unwrap();
 
     let compressed = uncompressed.compress(probs, alphabet);
     let reconstructed = compressed.decompress();


### PR DESCRIPTION
When creating one of the existing categorical distributions from (unquantized) floating-point probabilities, they calculate the *exact* optimal quantization, i.e., the quantization that minimizes the KL divergence to the unquantized distribution. This approach turns out to be excruciatingly slow, which is especially costly when applied to autoregressive models with a large vocabulary (where each categorical model is used only to encode or decode a single symbol before being discarded).

This PR will add additional variants of categorical distributions that use various combinations of:
- a simplified quantization method (similar to the one used by `LeakyQuantizer`) that will be much faster at the price of a small overhead in bitrate; and (optionally)
- lazy (symbol-local) quantization at encoding and decoding time rather than a global quantization of all symbols at model construction time.